### PR TITLE
require-relative: allow symbols as well as strings

### DIFF
--- a/load-relative.el
+++ b/load-relative.el
@@ -278,9 +278,12 @@ symbol.
 
 WARNING: it is best to to run this function before any
 buffer-setting or buffer changing operations."
-  (let ((require-string-name
-         (concat opt-prefix (file-name-sans-extension
-                             (file-name-nondirectory relative-file)))))
+  (let* ((relative-file (if (symbolp relative-file)
+                            (symbol-name relative-file)
+                          relative-file))
+         (require-string-name
+          (concat opt-prefix (file-name-sans-extension
+                              (file-name-nondirectory relative-file)))))
     (require (intern require-string-name)
              (relative-expand-file-name relative-file opt-file))))
 


### PR DESCRIPTION
This updates `require-relative' to allow a symbol to be passed; it is
simply converted to a string and used exactly as before.

Theoretically it could be optimised to avoid `intern' on a symbol, but
loading code is expensive enough I can't imagine it matters.

This allows for the more natural, to me:

    (require-relative 'usbhid-data)